### PR TITLE
Fix permanent drawer on mobile devices

### DIFF
--- a/src/components/NavbarDrawer.vue
+++ b/src/components/NavbarDrawer.vue
@@ -7,7 +7,7 @@
     width="300px"
   >
     <v-toolbar text dark class="px-3" height="64px">
-      <v-btn large block text outlined @click="drawer = !drawer">
+      <v-btn large block text outlined @click="drawer = false">
         Zamknij
         <v-icon large>mdi-close</v-icon>
       </v-btn>
@@ -20,7 +20,7 @@
         :key="item.title"
         router
         :to="item.link"
-        @click="drawer = !drawer"
+        @click="drawer = false"
       >
         <v-list-item-action>
           <v-icon large class="primary--text">{{ item.icon }}</v-icon>
@@ -32,7 +32,7 @@
       <v-list-item
         router
         :to="{ name: 'hardware' }"
-        @click="drawer = !drawer"
+        @click="drawer = false"
         v-if="auth"
       >
         <v-list-item-action>
@@ -45,7 +45,7 @@
       <v-list-item
         router
         href="https://kod.prz.edu.pl/junior"
-        @click="drawer = !drawer"
+        @click="drawer = false"
       >
         <v-list-item-action>
           <v-icon large class="primary--text">mdi-school</v-icon>
@@ -60,7 +60,7 @@
       <v-subheader>Użytkownik</v-subheader>
       <v-list-item
         router
-        @click="drawer = !drawer"
+        @click="drawer = false"
         :to="{ name: 'login' }"
         v-if="!auth"
       >
@@ -73,7 +73,7 @@
       </v-list-item>
       <v-list-item
         router
-        @click="drawer = !drawer"
+        @click="drawer = false"
         :to="{ name: 'register' }"
         v-if="!auth"
       >
@@ -86,7 +86,7 @@
       </v-list-item>
       <v-list-item
         router
-        @click="drawer = !drawer"
+        @click="drawer = false"
         :to="{ name: 'userProfile', params: { id: user.id } }"
         v-if="auth"
       >
@@ -99,7 +99,7 @@
       </v-list-item>
       <v-list-item
         router
-        @click="drawer = !drawer"
+        @click="drawer = false"
         :to="{ name: 'userPanel' }"
         v-if="auth"
       >
@@ -112,7 +112,7 @@
       </v-list-item>
       <v-list-item
         router
-        @click="drawer = !drawer"
+        @click="drawer = false"
         :to="{ name: 'adminPanel' }"
         v-if="role"
       >
@@ -126,7 +126,7 @@
       <v-list-item
         @click="
           logout();
-          drawer = !drawer;
+          drawer = false;
         "
         v-if="auth"
       >


### PR DESCRIPTION
This pull request fixes an issue with permanent drawer on mobile devices due to unpredictable `navDrawer` state changes.

Resolves #29